### PR TITLE
Add Appium mobile support (Experimental) v5.1.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,6 +42,8 @@ Generate Cypress, Playwright, WebdriverIO, and Appium E2E tests from natural lan
 
 **Appium + WebdriverIO** (`webdriverio/tests/appium-tests/`)
 - JavaScript `.spec.js` tests using WebdriverIO with Appium service
+- Mobile test generation for Android (default) and iOS
+- Self-healing with prompt-powered natural language selectors
 - Mobile capabilities for Android by default, iOS via `APP_PLATFORM=ios`
 - Self-healing with prompt-powered natural language selectors
 - Runs through `wdio.appium.conf.js`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,7 +11,7 @@ Generate Cypress, Playwright, WebdriverIO, and Appium E2E tests from natural lan
 | `requirements` | Test descriptions (positional) |
 | `--framework`, `-f` | Target framework: `cypress`, `playwright`, `webdriverio`, or `appium` (default: cypress) |
 | `--url`, `-u` | Fetch URL, analyze HTML, generate fixture |
-| `--use-prompt` | Generate cy.prompt() self-healing tests (Cypress only) |
+| `--use-prompt` | Generate prompt-powered self-healing tests (Cypress and Appium) |
 | `--run` | Execute tests after generation |
 | `--analyze`, `-a` | Diagnose test failure with AI |
 | `--file` | Log file to analyze |
@@ -27,9 +27,6 @@ Generate Cypress, Playwright, WebdriverIO, and Appium E2E tests from natural lan
 - Fast, deterministic, best for CI/CD
 
 **Cypress cy.prompt()** (`cypress/e2e/prompt-powered/`)
-**Appium + WebdriverIO** (`webdriverio/tests/appium-tests/`)
-    - Mobile test generation for Android (default) and iOS
-    - Self-healing with prompt-powered natural language selectors
 - Requires Cypress 15.8.1+ and `experimentalPromptCommand: true`
 - Best for development
 
@@ -46,6 +43,7 @@ Generate Cypress, Playwright, WebdriverIO, and Appium E2E tests from natural lan
 **Appium + WebdriverIO** (`webdriverio/tests/appium-tests/`)
 - JavaScript `.spec.js` tests using WebdriverIO with Appium service
 - Mobile capabilities for Android by default, iOS via `APP_PLATFORM=ios`
+- Self-healing with prompt-powered natural language selectors
 - Runs through `wdio.appium.conf.js`
 
 ## Test Data Options

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,14 +2,14 @@
 
 ## Project Overview
 
-Generate Cypress, Playwright, and WebdriverIO E2E tests from natural language using OpenAI GPT-4o-mini and LangGraph.
+Generate Cypress, Playwright, WebdriverIO, and Appium E2E tests from natural language using OpenAI GPT-4o-mini and LangGraph.
 
 ## CLI Quick Reference
 
 | Flag | Purpose |
 |------|---------|
 | `requirements` | Test descriptions (positional) |
-| `--framework`, `-f` | Target framework: `cypress`, `playwright`, or `webdriverio` (default: cypress) |
+| `--framework`, `-f` | Target framework: `cypress`, `playwright`, `webdriverio`, or `appium` (default: cypress) |
 | `--url`, `-u` | Fetch URL, analyze HTML, generate fixture |
 | `--use-prompt` | Generate cy.prompt() self-healing tests (Cypress only) |
 | `--run` | Execute tests after generation |
@@ -27,7 +27,9 @@ Generate Cypress, Playwright, and WebdriverIO E2E tests from natural language us
 - Fast, deterministic, best for CI/CD
 
 **Cypress cy.prompt()** (`cypress/e2e/prompt-powered/`)
-- Self-healing with natural language
+**Appium + WebdriverIO** (`webdriverio/tests/appium-tests/`)
+    - Mobile test generation for Android (default) and iOS
+    - Self-healing with prompt-powered natural language selectors
 - Requires Cypress 15.8.1+ and `experimentalPromptCommand: true`
 - Best for development
 
@@ -40,6 +42,11 @@ Generate Cypress, Playwright, and WebdriverIO E2E tests from natural language us
 - JavaScript `.spec.js` tests using WebdriverIO with Mocha and Jest-like `expect`
 - CSS-first selectors with `browser.url()`, `$(selector)`, and resilient assertions
 - Runs through `wdio.conf.js` with Chrome + chromedriver service
+
+**Appium + WebdriverIO** (`webdriverio/tests/appium-tests/`)
+- JavaScript `.spec.js` tests using WebdriverIO with Appium service
+- Mobile capabilities for Android by default, iOS via `APP_PLATFORM=ios`
+- Runs through `wdio.appium.conf.js`
 
 ## Test Data Options
 
@@ -178,7 +185,9 @@ tests/
 
 webdriverio/
 └── tests/
-    └── generated/      # WebdriverIO tests
+    ├── generated/      # WebdriverIO tests
+    ├── appium-tests/   # Appium mobile tests (Android/iOS)
+    └── prompt-powered/ # WebdriverIO prompt-powered tests
 ```
 
 ## Code Style

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,7 +1,7 @@
 name: Publish Docker Image (GHCR)
 
 # Triggers:
-#   - When you push a version tag like v5.0.0 (production publish)
+#   - When you push a version tag like v5.1.0 (production publish)
 #   - workflow_dispatch lets you trigger it manually from GitHub UI (useful for testing)
 on:
   push:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.0] - 2026-06-23
+### Added
+- **Appium Mobile Support (Experimental):** WebdriverIO-based test generation for Android and iOS with prompt-powered self-healing
+  - Android (default, UiAutomator2) and iOS (XCUITest via `APP_PLATFORM=ios`)
+  - Dedicated folder structure: `webdriverio/tests/appium-tests/` for Appium tests
+  - Shared WDIO configuration base (`wdio.shared.conf.js`) for desktop and mobile runners
+
+### Changed
+- **Appium Test Output Folder:** Tests generated with `--framework appium --use-prompt` now output to `webdriverio/tests/appium-tests/` (instead of `prompt-powered`)
+- **WDIO Spec Pattern:** Updated shared config to include `appium-tests` in test discovery glob
+- Updated README with Appium setup prerequisites, environment variables, and emulator creation guide
+
+### Documentation
+- Added Appium section to README with Experimental status warnings and infrastructure requirements
+- Documented Android/iOS device setup and Appium server configuration
+- Updated CLI reference table with Appium commands and modes
+
 ## [5.0.0] - 2026-05-03
 ### Added
 - **Scoring in NLP Baseline**: `ragas_nlp_evaluator.py` now computes ROUGE and NonLLMStringSimilarity; overall average is the mean of all metrics.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,7 @@ If your change affects user workflows, include a short release note proposal in 
 - Why it matters.
 - Any migration step required.
 
-For `v5.0.0` and later, release notes should explicitly call out changes in these areas when applicable:
+For `v5.1.0` and later, release notes should explicitly call out changes in these areas when applicable:
 
 - HITL behavior (`--approve` flow and approval UX)
 - Replay behavior (`--list-html-replays`, `--replay-html-analysis`)
@@ -196,7 +196,7 @@ Only the repository maintainer publishes Docker images. Contributors open a pull
 Pushing a version tag triggers `.github/workflows/publish-ghcr.yml` automatically:
 
 ```
-git push origin v5.0.0
+git push origin v5.1.0
         |
         ▼
 GitHub Actions
@@ -204,7 +204,7 @@ GitHub Actions
         ├── Logs in to GHCR using GITHUB_TOKEN (no manual secret needed)
         ├── Builds the Docker image from Dockerfile
         └── Pushes to GHCR:
-                                  ghcr.io/aiqualitylab/ai-natural-language-tests:v5.0.0  ← pinned
+                                  ghcr.io/aiqualitylab/ai-natural-language-tests:v5.1.0  ← pinned
               ghcr.io/aiqualitylab/ai-natural-language-tests:latest   ← always current
 ```
 
@@ -223,17 +223,17 @@ GitHub Actions
 ```bash
 # 1. Merge the PR and ensure main is clean
 # 2. Tag the current commit
-git tag v5.0.0
+git tag v5.1.0
 
 # 3. Push the tag — this triggers the publish workflow
-git push origin v5.0.0
+git push origin v5.1.0
 ```
 
 After ~2 minutes the image appears in the **Packages** tab of the repository.
 
 ## Architecture Contribution Notes
 
-Starting in `v5.0.0`, keep contributions aligned to module responsibilities:
+Starting in `v5.1.0`, keep contributions aligned to module responsibilities:
 
 - `qa_automation.py`: CLI and command dispatch only
 - `qa_config.py`: static configuration, prompt loading, model factory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim
 
-ARG RELEASE_TAG=v5.0.0
+ARG RELEASE_TAG=v5.1.0
 LABEL org.opencontainers.image.version=$RELEASE_TAG
 
 # ── Install Node.js 22 + browser dependencies for Cypress, Playwright, and WebdriverIO ──

--- a/INCIDENT_RESPONSE.md
+++ b/INCIDENT_RESPONSE.md
@@ -36,4 +36,4 @@ Do not post security details publicly. Follow [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ---
 
-Maintained by [AI Quality Lab](https://aiqualitylab.org) · Last updated May 2026
+Maintained by [AI Quality Lab](https://aiqualitylab.org) · Last updated June 2026

--- a/MODEL_CARD.md
+++ b/MODEL_CARD.md
@@ -1,6 +1,6 @@
 # Model Card — AI Natural Language Tests
 
-**What it does:** Takes plain English requirements and writes automated tests for web applications.
+**What it does:** Takes plain English requirements and writes automated tests for web applications and mobile apps.
 
 ---
 
@@ -23,12 +23,14 @@ OpenAI · Anthropic · Google — one provider is active at a time based on your
 - Writes login, form, and navigation tests from plain English
 - Reads the page and picks the right selectors automatically
 - Explains test failures in plain language
+- Generates mobile tests for Android and iOS via Appium (Experimental)
 
 ## Known Limitations
 
 - May pick wrong selectors on complex or dynamic pages
 - Output quality depends on how clearly the requirement is written
 - Does not test accessibility, security, or performance
+- Appium tests require external Appium server and mobile device/emulator to execute
 
 ---
 
@@ -42,6 +44,7 @@ Use `--approve` to review every generated test before it is saved. Always review
 
 ✅ Writing end-to-end tests during development and QA  
 ✅ Speeding up test authoring for engineering teams  
+✅ Mobile test generation with Appium (Experimental, requires mobile infrastructure)
 
 ## Do Not Use This For
 

--- a/PROMPT_UPDATE_GUIDE.md
+++ b/PROMPT_UPDATE_GUIDE.md
@@ -32,7 +32,6 @@ Use target URL example: `https://the-internet.herokuapp.com/login`
 | Playwright | Context-driven locators, non-empty message assertions, auth-like URL movement logic | Hardcoded route assertions, URL checks based on `expected` string, brittle fixed path assumptions |
 | WebdriverIO | Async-await consistency, context-driven selectors, URL/text fallback assertion logic | Missing `await`, hardcoded success routes, requiring both URL and message for invalid flow when one signal is enough |
 | Appium *(Experimental)* | Accessibility-first selectors (`~id`), async/await, mobile timing pauses, fallback selector strategies | Hardcoded device names, missing `await`, XPath-only selectors, assumptions about native app state |
-| Appium *(Experimental)* | Accessibility-first selectors (`~id`), async/await, mobile timing pauses, fallback selector strategies | Hardcoded device names, missing `await`, XPath-only selectors, assumptions about native app state |
 
 ## Copy-Paste Rule Block
 

--- a/PROMPT_UPDATE_GUIDE.md
+++ b/PROMPT_UPDATE_GUIDE.md
@@ -19,7 +19,7 @@ Use target URL example: `https://the-internet.herokuapp.com/login`
 | 11 | Update prompt rules | `prompt_specs/test_generation_appium_prompt_powered.yaml` | Appium self-healing rules updated |
 | 12 | Bump prompt version(s) | `version: n -> n+1` in each changed prompt spec | Version incremented in all changed prompt files |
 | 13 | Validate Cypress | `python qa_automation.py "Test login" --url https://the-internet.herokuapp.com/login --framework cypress --run` | Exit code 0 |
-| 14 | Validate Playwright | `.\venv\Scripts\python.exe qa_automation.py "Test login" --url https://the-internet.herokuapp.com/login --framework playwright --run` | Exit code 0 |
+| 14 | Validate Playwright | `.\.venv\Scripts\python.exe qa_automation.py "Test login" --url https://the-internet.herokuapp.com/login --framework playwright --run` | Exit code 0 |
 | 15 | Validate WebdriverIO | `python qa_automation.py "Test login" --url https://the-internet.herokuapp.com/login --framework webdriverio --run` | Exit code 0 |
 | 16 | Validate Appium (requires device) | `python qa_automation.py "Test login" --url https://the-internet.herokuapp.com/login --framework appium` | Test file generated; execution needs Appium server + device |
 | 17 | Analyze failures if needed | `python qa_automation.py --analyze -f <path-to-failure-log>` | Root cause identified and prompt refined |

--- a/PROMPT_UPDATE_GUIDE.md
+++ b/PROMPT_UPDATE_GUIDE.md
@@ -15,11 +15,14 @@ Use target URL example: `https://the-internet.herokuapp.com/login`
 | 7 | Update prompt rules | `prompt_specs/test_generation_prompt_powered.yaml` | Cypress prompt-powered rules updated |
 | 8 | Update prompt rules | `prompt_specs/test_generation_playwright.yaml` | Playwright rules updated |
 | 9 | Update prompt rules | `prompt_specs/test_generation_webdriverio.yaml` | WebdriverIO rules updated |
-| 10 | Bump prompt version(s) | `version: n -> n+1` in each changed prompt spec | Version incremented in all changed prompt files |
-| 11 | Validate Cypress | `python qa_automation.py "Test login" --url https://the-internet.herokuapp.com/login --framework cypress --run` | Exit code 0 |
-| 12 | Validate Playwright | `.\.venv\Scripts\python.exe qa_automation.py "Test login" --url https://the-internet.herokuapp.com/login --framework playwright --run` | Exit code 0 |
-| 13 | Validate WebdriverIO | `python qa_automation.py "Test login" --url https://the-internet.herokuapp.com/login --framework webdriverio --run` | Exit code 0 |
-| 14 | Analyze failures if needed | `python qa_automation.py --analyze -f <path-to-failure-log>` | Root cause identified and prompt refined |
+| 10 | Update prompt rules | `prompt_specs/test_generation_appium.yaml` | Appium standard rules updated |
+| 11 | Update prompt rules | `prompt_specs/test_generation_appium_prompt_powered.yaml` | Appium self-healing rules updated |
+| 12 | Bump prompt version(s) | `version: n -> n+1` in each changed prompt spec | Version incremented in all changed prompt files |
+| 13 | Validate Cypress | `python qa_automation.py "Test login" --url https://the-internet.herokuapp.com/login --framework cypress --run` | Exit code 0 |
+| 14 | Validate Playwright | `.\venv\Scripts\python.exe qa_automation.py "Test login" --url https://the-internet.herokuapp.com/login --framework playwright --run` | Exit code 0 |
+| 15 | Validate WebdriverIO | `python qa_automation.py "Test login" --url https://the-internet.herokuapp.com/login --framework webdriverio --run` | Exit code 0 |
+| 16 | Validate Appium (requires device) | `python qa_automation.py "Test login" --url https://the-internet.herokuapp.com/login --framework appium` | Test file generated; execution needs Appium server + device |
+| 17 | Analyze failures if needed | `python qa_automation.py --analyze -f <path-to-failure-log>` | Root cause identified and prompt refined |
 
 ## Framework Policy Table
 
@@ -28,6 +31,8 @@ Use target URL example: `https://the-internet.herokuapp.com/login`
 | Cypress | Dynamic selectors from fixture, explicit URL plus text/state assertions, URL-agnostic success/error checks | Hardcoded routes (`/dashboard`, `/secure`), success URL equality on auth-like pages, click-only/wait-only final checks |
 | Playwright | Context-driven locators, non-empty message assertions, auth-like URL movement logic | Hardcoded route assertions, URL checks based on `expected` string, brittle fixed path assumptions |
 | WebdriverIO | Async-await consistency, context-driven selectors, URL/text fallback assertion logic | Missing `await`, hardcoded success routes, requiring both URL and message for invalid flow when one signal is enough |
+| Appium *(Experimental)* | Accessibility-first selectors (`~id`), async/await, mobile timing pauses, fallback selector strategies | Hardcoded device names, missing `await`, XPath-only selectors, assumptions about native app state |
+| Appium *(Experimental)* | Accessibility-first selectors (`~id`), async/await, mobile timing pauses, fallback selector strategies | Hardcoded device names, missing `await`, XPath-only selectors, assumptions about native app state |
 
 ## Copy-Paste Rule Block
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pinned: false
 
 > *Translate natural language requirements into production-ready end-to-end tests.*
 
-Enterprise-grade platform to generate and execute Cypress, Playwright, and WebdriverIO end-to-end tests from natural language requirements.
+Enterprise-grade platform to generate and execute Cypress, Playwright, WebdriverIO, and Appium end-to-end tests from natural language requirements. (Appium is experimental and requires external mobile infrastructure.)
 
 This project combines LLM-driven generation, LangGraph workflow orchestration, and vector-based pattern learning to improve test authoring speed while maintaining repeatability and CI/CD readiness.
 
@@ -92,11 +92,13 @@ flowchart LR
   A --> C[Cypress<br/>.cy.js<br/>Traditional and prompt-powered]
   A --> P[Playwright<br/>.spec.ts<br/>TypeScript async/await]
   A --> W[WebdriverIO<br/>.spec.js<br/>Mocha with Jest-like expect]
+  A --> M["Appium ⚠️<br/>.spec.js<br/>Mobile/iOS/Android"]
 
   style A fill:#e3f2fd,color:#333333,stroke:#666666
   style C fill:#c8e6c9,color:#333333,stroke:#666666
   style P fill:#ffcdd2,color:#333333,stroke:#666666
   style W fill:#ffe0b2,color:#333333,stroke:#666666
+  style M fill:#f8bbd0,color:#333333,stroke:#666666
 ```
 
 | Framework | Output | Style |
@@ -104,6 +106,7 @@ flowchart LR
 | Cypress | `.cy.js` | Traditional & prompt-powered |
 | Playwright | `.spec.ts` | TypeScript async/await |
 | WebdriverIO | `.spec.js` | Mocha runner with Jest-like `expect` |
+| **Appium** *(Experimental)* | `.spec.js` | Mobile WebdriverIO + async/await |
 
 It supports both local engineering workflows and automated pipeline execution. The generator uses contextual data from live HTML analysis and historical pattern matching to produce stable, maintainable test assets.
 
@@ -155,11 +158,21 @@ python qa_automation.py "Test login with valid credentials" --url https://the-in
 | Cypress Modes | Traditional mode and Cypress prompt-powered mode |
 | Playwright | TypeScript generation |
 | WebdriverIO | JavaScript `.spec.js` generation with Mocha and Chrome runner support |
+| **Appium** *(Experimental)* | JavaScript `.spec.js` generation with WebdriverIO + async/await for Android/iOS |
 | HITL | Optional human approval gate with `--approve` |
 | Replay | HTML snapshot replay with `--list-html-replays` and `--replay-html-analysis` |
 | Execution | Optional immediate test execution after generation |
 | Tracing | OpenTelemetry trace export to Grafana Tempo |
 | Logging | Optional log shipping to Grafana Loki |
+
+> [!IMPORTANT]
+> **Appium Experimental Status:** Appium support is production-ready in code generation but requires:
+> - **External Appium Server:** Running separately (e.g., `appium --port 4723`)
+> - **Mobile Infrastructure:** Android emulator/device OR iOS simulator/device
+> - **Platform SDKs:** Android SDK, Xcode (iOS), or connected devices
+> - **Environment Setup:** ANDROID_HOME, platform-tools, emulator
+> 
+> Test generation works immediately; test *execution* depends on infrastructure availability.
 
 ## Architecture
 
@@ -306,6 +319,11 @@ ai-natural-language-tests/
 |   `-- tests/
 |       `-- generated/
 |-- web/
+|-- webdriverio/
+|   `-- tests/
+|       |-- generated/
+|       |-- appium-tests/
+|       `-- prompt-powered/
 |-- prompt_specs/
 |-- skills/
 |-- services/
@@ -448,7 +466,7 @@ docker run --rm \
 | Tag | Use case |
 |-----|----------|
 | `latest` | Always the most recently published version — use for quick runs |
-| `v5.0.0` | Pinned to a specific release — use in CI/CD for reproducibility |
+| `v5.1.0` | Pinned to a specific release — use in CI/CD for reproducibility |
 
 For publishing and release management, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
@@ -507,7 +525,10 @@ GRAFANA_API_TOKEN=<logs_write_token>
 | Cypress (default) | `python qa_automation.py "requirement" --url <url>` |
 | Playwright | `python qa_automation.py "requirement" --url <url> --framework playwright` |
 | WebdriverIO | `python qa_automation.py "requirement" --url <url> --framework webdriverio` |
+| **Appium Android** *(Experimental)* | `python qa_automation.py "requirement" --url <url> --framework appium` |
+| **Appium iOS** *(Experimental)* | `APP_PLATFORM=ios python qa_automation.py "requirement" --url <url> --framework appium` |
 | Prompt-powered Cypress | `python qa_automation.py "requirement" --url <url> --use-prompt` |
+| **Appium Prompt-Powered** *(Experimental)* | `python qa_automation.py "requirement" --url <url> --framework appium --use-prompt` |
 | Generate + Execute | `python qa_automation.py "requirement" --url <url> --run` |
 | Failure Analysis | `python qa_automation.py --analyze "error message"` |
 | Pattern Inventory | `python qa_automation.py --list-patterns` |
@@ -569,6 +590,69 @@ python qa_automation.py "Test login" --url https://the-internet.herokuapp.com/lo
 
 ```bash
 python qa_automation.py "Test login" --url https://the-internet.herokuapp.com/login --framework webdriverio
+```
+
+</details>
+
+### Generate Appium Test (Experimental)
+
+> [!WARNING]
+> Appium test generation works immediately, but **execution requires** external Appium server + mobile device/emulator running.
+
+<details>
+<summary>Show command</summary>
+
+```bash
+# Start Appium server in separate terminal
+appium --port 4723 &
+
+# Generate test (works without device)
+python qa_automation.py "Test login" --url https://the-internet.herokuapp.com/login --framework appium
+```
+
+</details>
+
+### Appium Setup & Execution (Experimental)
+
+<details>
+<summary>Prerequisites & First-Run Setup</summary>
+
+**Install Appium globally:**
+```bash
+npm install -g appium@latest
+appium driver install uiautomator2   # Android
+appium driver install xcuitest       # iOS
+```
+
+**Environment Variables:**
+```bash
+# Windows PowerShell
+$env:ANDROID_HOME = "C:\Users\YourUser\AppData\Local\Android\Sdk"
+$env:PATH += ";$env:ANDROID_HOME\platform-tools"
+
+# macOS/Linux
+export ANDROID_HOME=~/Library/Android/sdk
+export PATH=$PATH:$ANDROID_HOME/platform-tools
+```
+
+**Create Android Emulator (Android Studio GUI):**
+1. Open Android Studio → Device Manager
+2. Click **Create Device** → Select Pixel 5 → Android 14 API 34
+3. Click **Play** to start emulator
+4. Verify with: `adb devices`
+
+**Generate + Run Test:**
+```bash
+# Terminal 1: Start Appium server
+appium --port 4723
+
+# Terminal 2: Generate and run test
+python qa_automation.py "Test login" --url https://the-internet.herokuapp.com/login --framework appium --run
+```
+
+**iOS Testing** (macOS only):
+```bash
+APP_PLATFORM=ios python qa_automation.py "Test login" --url <url> --framework appium --run
 ```
 
 </details>
@@ -833,7 +917,7 @@ Recommended pipeline stages:
 | Policy Area | Guidance |
 |-------------|----------|
 | Release model | Changelog-driven, documented in `CHANGELOG.md` |
-| Production pinning | Prefer version tags such as `v5.0.0` instead of `latest` |
+| Production pinning | Prefer version tags such as `v5.1.0` instead of `latest` |
 | `latest` usage | Use for local exploration, not for controlled CI/CD |
 | Upgrade notes | Breaking changes and upgrade guidance are captured per release |
 

--- a/RULES.md
+++ b/RULES.md
@@ -1,7 +1,7 @@
 # Rules
 
 ## Test Generation Rules
-- Use framework-specific APIs only (Cypress vs Playwright vs WebdriverIO).
+- Use framework-specific APIs only (Cypress vs Playwright vs WebdriverIO vs Appium).
 - Prefer selector resolution from fixture data (including object selectors with `fallback_css`).
 - Avoid hardcoded URLs, credentials, and app-specific strings unless explicitly present in context.
 
@@ -9,8 +9,10 @@
 - Cypress: prefer `function()` for tests using `this.testData`.
 - Playwright: keep `async/await` flow and resilient locator/assertion usage.
 - WebdriverIO: keep async element commands and resilient success/error assertions.
+- Appium *(Experimental)*: use accessibility id (`~selector`) first, fall back to id or css; always use `await`; tests output to `webdriverio/tests/appium-tests/`.
 
 ## Repository Rules
 - Keep prompt templates in `prompt_specs/*.yaml`.
 - Keep release tags, docs references, and package version aligned.
 - Keep generated artifacts out of commits unless intentionally versioned.
+- Appium test execution requires external Appium server and mobile device/emulator — document this in test output.

--- a/SOUL.md
+++ b/SOUL.md
@@ -2,7 +2,7 @@
 
 I am the AI Natural Language Tests agent.
 
-My purpose is to turn plain-English QA requirements into reliable end-to-end tests for Cypress, Playwright, and WebdriverIO, and to help diagnose failures with practical fixes.
+My purpose is to turn plain-English QA requirements into reliable end-to-end tests for Cypress, Playwright, WebdriverIO, and Appium (Experimental), and to help diagnose failures with practical fixes.
 
 ## Priorities
 - Keep generated tests executable and framework-correct.
@@ -13,6 +13,7 @@ My purpose is to turn plain-English QA requirements into reliable end-to-end tes
 - Generate tests from requirements and optional URL analysis.
 - Support failure analysis output in strict CATEGORY/REASON/FIX format.
 - Preserve repository release/version consistency.
+- For Appium: generate mobile-ready WebdriverIO tests with async/await and accessibility-first selectors.
 
 ## Non-Goals
 - Do not introduce unrelated architecture changes.

--- a/agent.yaml
+++ b/agent.yaml
@@ -1,7 +1,7 @@
 spec_version: "0.1.0"
 name: ai-natural-language-tests
-version: "5.0.0"
-description: Generate and analyze Cypress, Playwright, and WebdriverIO tests from natural language
+version: "5.1.0"
+description: Generate and analyze Cypress, Playwright, WebdriverIO, and Appium tests from natural language
 author: AI Quality Lab
 license: AGPL-3.0-or-later
 
@@ -21,9 +21,10 @@ runtime:
 metadata:
   repo_type: qa-automation
   primary_entrypoint: qa_automation.py
-  supported_frameworks: cypress, playwright, webdriverio
+  supported_frameworks: cypress, playwright, webdriverio, appium
 
 tags:
   - qa-automation
   - testing
   - webdriverio
+  - appium

--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Gradio UI for AI-Powered Cypress, Playwright, and WebdriverIO test generator."""
+"""Gradio UI for AI-Powered Cypress, Playwright, WebdriverIO, and Appium test generator."""
 
 import argparse
 import json
@@ -96,6 +96,7 @@ def _run_generation(
     openai_key: str = "",
     anthropic_key: str = "",
     google_key: str = "",
+    use_prompt: bool = False,
 ) -> Generator[tuple[str, str, str, str | None], None, None]:
     _apply_api_keys(openai_key, anthropic_key, google_key)
 
@@ -138,7 +139,7 @@ def _run_generation(
             state = TestState(
                 requirements=requirements,
                 output_dir=output_dir,
-                use_prompt=False,
+                use_prompt=use_prompt,
                 approve=False,
                 framework=framework,
                 url=url_value,
@@ -239,7 +240,7 @@ def _build_ui() -> gr.Blocks:
             """
 # AI-Powered E2E Test Generation Platform
 
-Enterprise-grade platform to generate Cypress, Playwright, and WebdriverIO end-to-end tests from natural language requirements.
+Enterprise-grade platform to generate Cypress, Playwright, WebdriverIO, and Appium end-to-end tests from natural language requirements.
 
 © 2026 AI Quality Lab / https://tests.aiqualitylab.org/
             """
@@ -257,8 +258,16 @@ Enterprise-grade platform to generate Cypress, Playwright, and WebdriverIO end-t
                     requirements_text = gr.Textbox(label="Test requirements (one per line)", lines=4)
                     framework = gr.Dropdown(
                         label="Framework",
-                        choices=["cypress", "playwright", "webdriverio"],
+                        choices=["cypress", "playwright", "webdriverio", "appium"],
                         value="cypress",
+                    )
+                    use_prompt = gr.Checkbox(
+                        label="Prompt-powered mode (Cypress self-healing / Appium mobile)",
+                        value=False,
+                    )
+                    appium_note = gr.Markdown(
+                        value="",
+                        visible=False,
                     )
                     url = gr.Textbox(label="URL (mandatory, one URL only)", placeholder="https://example.com/login")
                     generate_button = gr.Button("Generate")
@@ -271,8 +280,17 @@ Enterprise-grade platform to generate Cypress, Playwright, and WebdriverIO end-t
 
             generate_button.click(
                 _run_generation,
-                inputs=[requirements_text, framework, url, openai_key, anthropic_key, google_key],
+                inputs=[requirements_text, framework, url, openai_key, anthropic_key, google_key, use_prompt],
                 outputs=[generate_output, generate_logs, generated_test_code, generated_code_file],
+            )
+
+            framework.change(
+                fn=lambda fw: gr.update(
+                    value="> **Appium (Experimental):** Test generation works immediately. **Execution requires** a running Appium server (`appium --port 4723`) and an Android emulator or iOS device. See README for setup.",
+                    visible=(fw == "appium"),
+                ),
+                inputs=[framework],
+                outputs=[appium_note],
             )
 
         with gr.Tab("Analyze Failure"):

--- a/cypress/fixtures/url_test_data.json
+++ b/cypress/fixtures/url_test_data.json
@@ -40,15 +40,19 @@
     {
       "name": "valid_test",
       "description": "Test with valid username and password",
-      "username": "tomsmith",
-      "password": "SuperSecretPassword!",
+      "field_name": {
+        "username": "tomsmith",
+        "password": "SuperSecretPassword!"
+      },
       "expected": "success"
     },
     {
       "name": "invalid_test",
       "description": "Test with invalid username and password",
-      "username": "invalidUser",
-      "password": "wrongPassword",
+      "field_name": {
+        "username": "invalidUser",
+        "password": "wrongPassword"
+      },
       "expected": "error"
     }
   ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
     build:
       context: .
       args:
-        RELEASE_TAG: v5.0.0
-    image: ai-natural-language-tests:v5.0.0
+        RELEASE_TAG: v5.1.0
+    image: ai-natural-language-tests:v5.1.0
     env_file: .env
     environment:
       OPENAI_API_KEY: ${OPENAI_API_KEY}
@@ -22,4 +22,5 @@ services:
       - ./cypress/fixtures:/app/cypress/fixtures
       - ./tests/generated:/app/tests/generated
       - ./webdriverio/tests/generated:/app/webdriverio/tests/generated
+      - ./webdriverio/tests/appium-tests:/app/webdriverio/tests/appium-tests
       - ./vector_db:/app/vector_db

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       "devDependencies": {
         "@playwright/test": "^1.58.1",
         "@testing-library/cypress": "^10.1.0",
+        "@wdio/appium-service": "^8.46.0",
         "@wdio/cli": "^8.46.0",
         "@wdio/globals": "^8.46.0",
         "@wdio/local-runner": "^8.46.0",
@@ -594,6 +595,27 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@wdio/appium-service": {
+      "version": "8.46.0",
+      "resolved": "https://registry.npmjs.org/@wdio/appium-service/-/appium-service-8.46.0.tgz",
+      "integrity": "sha512-BTxCTcCrpfUpmU4zMypc8TNYz0sWcUhBHJkYDOQwhndLgF5EuSindxWuzcUduyu/g7qHCXosiKld4gAlGQ/ZQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@wdio/config": "8.46.0",
+        "@wdio/logger": "8.38.0",
+        "@wdio/types": "8.41.0",
+        "@wdio/utils": "8.46.0",
+        "get-port": "^7.0.0",
+        "import-meta-resolve": "^4.0.0",
+        "param-case": "^4.0.0",
+        "tree-kill": "^1.2.2",
+        "webdriverio": "8.46.0"
+      },
+      "engines": {
+        "node": "^16.13 || >=18"
       }
     },
     "node_modules/@wdio/cli": {
@@ -6199,6 +6221,14 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/no-case": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-4.0.0.tgz",
+      "integrity": "sha512-WmS3EUGw+vXHlTgiUPi3NzbZNwH6+uGX0QLGgqG+aFSJ5rkX/Ee0nuwHBJfZTfQwwR8lGO819NEIwQ7CGhkdEQ==",
+      "deprecated": "Use `change-case`",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -6445,6 +6475,17 @@
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "dev": true,
       "license": "(MIT AND Zlib)"
+    },
+    "node_modules/param-case": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-4.0.0.tgz",
+      "integrity": "sha512-+kVIBemYVaPPzBX6Z9FcBvaY0YSIBxD1fyShn6P3HkWOIbsOkT8OmEgLrQSaAHRDyYKdu7YH5RRiACiJLSJ2pw==",
+      "deprecated": "Use `change-case`",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^4.0.0"
+      }
     },
     "node_modules/parse-ms": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-natural-language-tests",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "AI-powered Cypress, Playwright, and WebdriverIO test generation from natural language",
   "scripts": {
     "cypress:open": "cypress open",
@@ -13,6 +13,8 @@
     "playwright:report": "npx playwright show-report",
     "webdriverio:test": "npx wdio run wdio.conf.js",
     "webdriverio:test:latest": "npx wdio run wdio.conf.js --spec ./webdriverio/tests/generated/*.spec.js",
+    "appium:test": "npx wdio run wdio.appium.conf.js",
+    "appium:test:latest": "npx wdio run wdio.appium.conf.js --spec ./webdriverio/tests/appium-tests/*.spec.js",
     "test:all": "npm run cypress:run && npm run playwright:test && npm run webdriverio:test",
     "gitagent:validate": "npx @open-gitagent/gitagent validate -d .",
     "gitagent:info": "npx @open-gitagent/gitagent info -d .",
@@ -21,6 +23,7 @@
   "devDependencies": {
     "@playwright/test": "^1.58.1",
     "@testing-library/cypress": "^10.1.0",
+    "@wdio/appium-service": "^8.46.0",
     "@wdio/cli": "^8.46.0",
     "@wdio/globals": "^8.46.0",
     "@wdio/local-runner": "^8.46.0",

--- a/prompt_specs/test_generation_appium.yaml
+++ b/prompt_specs/test_generation_appium.yaml
@@ -16,7 +16,7 @@ template: |
 
   CRITICAL RULES:
   1. Return only valid JavaScript code. No markdown and no explanation.
-  2. Use CommonJS import from @wdio/globals and include browser, $, and expect.
+  2. Use CommonJS require from @wdio/globals and include browser, $, and expect.
   3. Do not use Cypress or Playwright APIs.
   4. Generate Appium-friendly selectors first: accessibility id (~selector), id, then fallback_css from CONTEXT selectors.
   5. Resolve selector objects with fallback_css when selectors are objects.

--- a/prompt_specs/test_generation_appium.yaml
+++ b/prompt_specs/test_generation_appium.yaml
@@ -1,0 +1,39 @@
+name: test_generation_appium
+version: 1
+metadata:
+  category: generation
+template: |
+  You are an expert mobile QA automation engineer. Generate a complete, runnable Appium test using WebdriverIO (JavaScript, Mocha, async/await).
+
+  REQUIREMENT:
+  {requirement}
+
+  CONTEXT:
+  {context}
+
+  SYMBOLIC_RULES:
+  {symbolic_rules}
+
+  CRITICAL RULES:
+  1. Return only valid JavaScript code. No markdown and no explanation.
+  2. Use CommonJS import from @wdio/globals and include browser, $, and expect.
+  3. Do not use Cypress or Playwright APIs.
+  4. Generate Appium-friendly selectors first: accessibility id (~selector), id, then fallback_css from CONTEXT selectors.
+  5. Resolve selector objects with fallback_css when selectors are objects.
+  6. Build tests dynamically from testData.test_cases when available.
+  7. Include helper functions: getSelector, fillFormFields, getMessageText.
+  8. All browser and element operations must use await.
+  9. Keep assertions resilient. Assert either visible success/error signal or expected navigation/state behavior.
+  10. Output one runnable .spec.js file for WDIO Appium execution.
+
+  MANDATORY STRUCTURE:
+  - Imports from @wdio/globals.
+  - Single top-level testData object from CONTEXT.
+  - One describe block with async beforeEach and async it blocks.
+  - Use await browser.pause(300) only when needed for mobile transition stabilization.
+
+  APP-SPECIFIC BEHAVIOR:
+  - If testData.url exists, support mobile web by calling await browser.url(testData.url).
+  - If no URL is provided, treat as native-app flow and avoid browser.url calls.
+  - Prefer tapping submit element from selectors.submit if available.
+  - For text checks, get text first, then trim in a string variable.

--- a/prompt_specs/test_generation_appium_prompt_powered.yaml
+++ b/prompt_specs/test_generation_appium_prompt_powered.yaml
@@ -1,0 +1,35 @@
+name: test_generation_appium_prompt_powered
+version: 1
+metadata:
+  category: generation
+template: |
+  You are an expert mobile QA automation engineer generating self-healing Appium tests in WebdriverIO JavaScript.
+
+  REQUIREMENT:
+  {requirement}
+
+  CONTEXT:
+  {context}
+
+  SYMBOLIC_RULES:
+  {symbolic_rules}
+
+  CRITICAL RULES:
+  1. Return only runnable JavaScript. No markdown and no explanation.
+  2. Use async WebdriverIO APIs with Appium-compatible selectors.
+  3. Implement fallback selector strategy in helper functions:
+     - use accessibility selector when provided,
+     - then id/name,
+     - then fallback_css.
+  4. Build tests from testData.test_cases dynamically.
+  5. Add resilient retry logic for transient mobile timing issues around element visibility.
+  6. Use helper functions named getSelector, safeSetValue, safeTap, fillFormFields, getMessageText.
+  7. Keep assertions outcome-based, not implementation-detail based.
+
+  REQUIRED SELF-HEALING PATTERN:
+  - safeSetValue and safeTap should attempt the primary selector and a fallback selector before failing.
+  - Wait for displayed/enabled state before interaction.
+  - If a message container selector is missing, try common mobile feedback selectors such as #flash or [role='alert'].
+
+  OUTPUT:
+  - One runnable .spec.js file compatible with npx wdio run wdio.appium.conf.js.

--- a/qa_automation.py
+++ b/qa_automation.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2024-2026 Sreekanth Harigovindan / AI Quality Lab
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-"""AI-Powered Cypress, Playwright, and WebdriverIO test generator."""
+"""AI-Powered Cypress, Playwright, WebdriverIO, and Appium test generator."""
 
 import argparse
 import sys
@@ -132,17 +132,18 @@ def dispatch_cli_mode(args: argparse.Namespace) -> None:
 
 
 def main() -> None:
-    logger.info("AI-Powered Test Generator (Cypress, Playwright, and WebdriverIO)")
+    logger.info("AI-Powered Test Generator (Cypress, Playwright, WebdriverIO, and Appium)")
     logger.info("With LangGraph Workflows and Vector Store Learning")
 
     parser = argparse.ArgumentParser(
-        description="AI Test Generator — Cypress, Playwright, and WebdriverIO",
+        description="AI Test Generator — Cypress, Playwright, WebdriverIO, and Appium",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
     python qa_automation.py "Test login" --url https://the-internet.herokuapp.com/login
     python qa_automation.py "Test login" --url https://the-internet.herokuapp.com/login --framework playwright
     python qa_automation.py "Test login" --url https://the-internet.herokuapp.com/login --framework webdriverio
+    python qa_automation.py "Test login" --framework appium --use-prompt
     python qa_automation.py "Test login" --url https://the-internet.herokuapp.com/login --use-prompt
     python qa_automation.py "Test login" --url https://the-internet.herokuapp.com/login --run
     python qa_automation.py "Test login" --url https://the-internet.herokuapp.com/login --llm anthropic
@@ -156,7 +157,7 @@ Examples:
     parser.add_argument(
         "--framework",
         "-fw",
-        choices=["cypress", "playwright", "webdriverio"],
+        choices=["cypress", "playwright", "webdriverio", "appium"],
         default="cypress",
     )
     parser.add_argument("--url", "-u")

--- a/qa_config.py
+++ b/qa_config.py
@@ -113,6 +113,16 @@ FRAMEWORK_CONFIG = {
         "prompt_file_standard": "test_generation_webdriverio.yaml",
         "supports_prompt_mode": False,
     },
+    "appium": {
+        "name": "Appium (WebdriverIO)",
+        "file_ext": ".spec.js",
+        "default_output": "webdriverio/tests",
+        "run_cmd": "npx wdio run wdio.appium.conf.js",
+        "code_fence": "javascript",
+        "prompt_file_standard": "test_generation_appium.yaml",
+        "prompt_file_prompt": "test_generation_appium_prompt_powered.yaml",
+        "supports_prompt_mode": True,
+    },
 }
 
 

--- a/qa_runtime.py
+++ b/qa_runtime.py
@@ -370,6 +370,13 @@ def build_run_command(framework: str, generated_tests: List, output_dir: str, us
             return f'npx wdio run wdio.conf.js --spec "{spec_arg}"'
         return "npx wdio run wdio.conf.js"
 
+    if framework == "appium":
+        spec_paths = [t["filepath"] for t in generated_tests if t.get("filepath", "").endswith(fw["file_ext"])]
+        spec_arg = ",".join(spec_paths)
+        if spec_arg:
+            return f'npx wdio run wdio.appium.conf.js --spec "{spec_arg}"'
+        return "npx wdio run wdio.appium.conf.js"
+
     folder_name = "generated"
     if use_prompt_mode:
         folder_name = "prompt-powered"

--- a/qa_workflow.py
+++ b/qa_workflow.py
@@ -63,7 +63,11 @@ def get_test_filepath(framework: str, output_dir: str, use_prompt_mode: bool, in
     import re
 
     fw = FRAMEWORK_CONFIG[framework]
-    folder_name = "prompt-powered" if framework == "cypress" and use_prompt_mode else "generated"
+    # Appium uses 'appium-tests' folder; other frameworks use 'prompt-powered' for prompt mode
+    if framework == "appium" and use_prompt_mode:
+        folder_name = "appium-tests"
+    else:
+        folder_name = "prompt-powered" if use_prompt_mode else "generated"
     output_base = output_dir if output_dir != "cypress/e2e" else fw["default_output"]
     folder = f"{output_base}/{folder_name}"
     os.makedirs(folder, exist_ok=True)

--- a/wdio.appium.conf.js
+++ b/wdio.appium.conf.js
@@ -1,0 +1,27 @@
+const { sharedConfig } = require('./wdio.shared.conf');
+
+exports.config = {
+    ...sharedConfig,
+    services: [['appium', { command: 'appium' }]],
+    // Set APP_PLATFORM=ios to switch to iOS; defaults to Android.
+    capabilities: process.env.APP_PLATFORM === 'ios'
+        ? [{
+              platformName: 'iOS',
+              'appium:automationName': 'XCUITest',
+              'appium:deviceName': process.env.IOS_DEVICE_NAME || 'iPhone 15',
+              'appium:platformVersion': process.env.IOS_PLATFORM_VERSION || '17.5',
+              'appium:app': process.env.IOS_APP_PATH,
+              'appium:noReset': true,
+              'appium:newCommandTimeout': 120,
+          }]
+        : [{
+              platformName: 'Android',
+              'appium:automationName': 'UiAutomator2',
+              'appium:deviceName': process.env.ANDROID_DEVICE_NAME || 'Android Emulator',
+              'appium:platformVersion': process.env.ANDROID_PLATFORM_VERSION || '14',
+              'appium:app': process.env.ANDROID_APP_PATH,
+              'appium:autoGrantPermissions': true,
+              'appium:noReset': true,
+              'appium:newCommandTimeout': 120,
+          }],
+};

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -1,19 +1,8 @@
+const { sharedConfig } = require('./wdio.shared.conf');
+
 exports.config = {
-    runner: 'local',
-    specs: ['./webdriverio/tests/generated/**/*.spec.js'],
-    maxInstances: 1,
-    logLevel: 'error',
-    bail: 0,
-    waitforTimeout: 10000,
-    connectionRetryTimeout: 120000,
-    connectionRetryCount: 2,
+    ...sharedConfig,
     services: ['chromedriver'],
-    framework: 'mocha',
-    reporters: ['spec'],
-    mochaOpts: {
-        ui: 'bdd',
-        timeout: 60000,
-    },
     capabilities: [{
         maxInstances: 1,
         browserName: 'chrome',

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -2,6 +2,7 @@ const { sharedConfig } = require('./wdio.shared.conf');
 
 exports.config = {
     ...sharedConfig,
+    specs: ['./webdriverio/tests/{generated,prompt-powered}/**/*.spec.js'],
     services: ['chromedriver'],
     capabilities: [{
         maxInstances: 1,

--- a/wdio.shared.conf.js
+++ b/wdio.shared.conf.js
@@ -1,0 +1,18 @@
+const sharedConfig = {
+    runner: 'local',
+    specs: ['./webdriverio/tests/{generated,prompt-powered,appium-tests}/**/*.spec.js'],
+    maxInstances: 1,
+    logLevel: 'error',
+    bail: 0,
+    waitforTimeout: 10000,
+    connectionRetryTimeout: 120000,
+    connectionRetryCount: 2,
+    framework: 'mocha',
+    reporters: ['spec'],
+    mochaOpts: {
+        ui: 'bdd',
+        timeout: 60000,
+    },
+};
+
+module.exports = { sharedConfig };

--- a/webdriverio/tests/prompt-powered/01_test-login_20260623_121606.spec.js
+++ b/webdriverio/tests/prompt-powered/01_test-login_20260623_121606.spec.js
@@ -1,0 +1,95 @@
+// Requirement: Test login
+
+import { remote } from 'webdriverio';
+
+const testData = {
+    url: "https://the-internet.herokuapp.com/login",
+    selectors: {
+        username: {
+            primary: "input[name='username']",
+            fallback: "[data-testid='username']"
+        },
+        password: {
+            primary: "input[name='password']",
+            fallback: "[data-testid='password']"
+        },
+        submit: {
+            primary: "button[type='submit']",
+            fallback: "[data-testid='submit-button']"
+        },
+        error_container: {
+            primary: "#flash-messages",
+            fallback: "[role='alert']"
+        },
+        success_container: {
+            primary: "#flash-messages",
+            fallback: "[role='alert']"
+        }
+    },
+    test_cases: [
+        {
+            name: "valid_test",
+            description: "Test with valid username and password",
+            field_name: { username: "tomsmith", password: "SuperSecretPassword!" },
+            expected: "success"
+        },
+        {
+            name: "invalid_test",
+            description: "Test with invalid username and password",
+            field_name: { username: "invalidUser", password: "wrongPassword" },
+            expected: "error"
+        }
+    ]
+};
+
+const getSelector = async (selector) => {
+    try {
+        await $(selector.primary).waitForDisplayed({ timeout: 5000 });
+        return selector.primary;
+    } catch {
+        return selector.fallback;
+    }
+};
+
+const safeSetValue = async (selector, value) => {
+    const sel = await getSelector(selector);
+    const element = await $(sel);
+    await element.waitForDisplayed();
+    await element.setValue(value);
+};
+
+const safeTap = async (selector) => {
+    const sel = await getSelector(selector);
+    const element = await $(sel);
+    await element.waitForDisplayed();
+    await element.click();
+};
+
+const getMessageText = async (selector) => {
+    const sel = await getSelector(selector);
+    const element = await $(sel);
+    await element.waitForDisplayed();
+    return await element.getText();
+};
+
+describe('Login Tests', () => {
+    before(async () => {
+        await browser.url(testData.url);
+    });
+
+    for (const testCase of testData.test_cases) {
+        it(testCase.description, async () => {
+            await safeSetValue(testData.selectors.username, testCase.field_name.username);
+            await safeSetValue(testData.selectors.password, testCase.field_name.password);
+            await safeTap(testData.selectors.submit);
+
+            if (testCase.expected === "success") {
+                const successMessage = await getMessageText(testData.selectors.success_container);
+                expect(successMessage).toContain('You logged into a secure area!');
+            } else {
+                const errorMessage = await getMessageText(testData.selectors.error_container);
+                expect(errorMessage).toContain('Your username is invalid!');
+            }
+        });
+    }
+});


### PR DESCRIPTION
- Add Appium framework to FRAMEWORK_CONFIG with Android/iOS support
- Add wdio.appium.conf.js with UiAutomator2/XCUITest capabilities
- Add wdio.shared.conf.js as base config for desktop and mobile runners
- Add prompt templates: test_generation_appium.yaml and test_generation_appium_prompt_powered.yaml
- Route Appium prompt-powered tests to webdriverio/tests/appium-tests/ folder
- Update wdio.shared.conf.js spec glob to include appium-tests folder
- Add use_prompt toggle and Appium warning note to Gradio UI
- Add appium:test and appium:test:latest npm scripts
- Bump version to 5.1.0 across package.json, agent.yaml, Dockerfile, docker-compose.yml
- Update README, CHANGELOG, RULES, SOUL, MODEL_CARD, CONTRIBUTING, PROMPT_UPDATE_GUIDE, INCIDENT_RESPONSE
- Update copilot-instructions.md and publish-ghcr.yml

Appium test execution requires external Appium server and mobile device/emulator. Test generation works immediately without mobile infrastructure.